### PR TITLE
Flat map errors

### DIFF
--- a/lib/mix/task/gettext_check.ex
+++ b/lib/mix/task/gettext_check.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.GettextCheck do
       Mix.raise("No locale files found in #{path} for locale: '#{locale}'")
     end
 
-    errors = Enum.map(files, &GettextCheck.check/1)
+    errors = Enum.flat_map(files, &GettextCheck.check/1)
 
     if errors != [] do
       message = """


### PR DESCRIPTION
Errors are returned as an array of arrays of errors, when there are no errors it is returned as
```
[[], [], []]
```
using flat_map squashes them into an empty array.